### PR TITLE
すべての種類のAreaクラスが継承するAbstractAreaクラスの作成

### DIFF
--- a/Doubutsu_pde/AbstractArea_pde.pde
+++ b/Doubutsu_pde/AbstractArea_pde.pde
@@ -1,0 +1,13 @@
+abstract class AbstractArea {
+  int posX;
+  int posY;
+  int tate;
+  int yoko;
+  AbstractArea(int posX, int posY, int yoko, int tate) {
+    this.posX = posX;
+    this.posY = posY;
+    this.yoko = yoko;
+    this.tate = tate;
+  }
+  abstract void draw();
+}


### PR DESCRIPTION
エリアの左上座標（poX,poY)と縦横幅(tate,yoko)をフィールドに持つクラスを実装した.